### PR TITLE
docs: add link to OpenCode port (opencode-brain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,21 @@ memvid timeline .claude/mind.mv2        # view timeline
 
 <br />
 
+## OpenCode Support
+
+Want to use this with OpenCode? Check out [**opencode-brain**](https://github.com/deiviuds/opencode-brain) - a fully compatible port that shares the same `.claude/mind.mv2` file format.
+
+Both tools can be used interchangeably on the same project.
+
+**Install:**
+```bash
+npm install opencode-brain
+```
+
+[View on npm →](https://www.npmjs.com/package/opencode-brain)
+
+<br />
+
 ## FAQ
 
 <details>


### PR DESCRIPTION
I've created an OpenCode-compatible version of claude-brain called **opencode-brain**. It maintains 100% file format compatibility with the `.claude/mind.mv2` file, so users can use both tools interchangeably on the same project.

## What is opencode-brain?

opencode-brain is a port of claude-brain for OpenCode users, providing the same photographic memory functionality.

## Key Features
- **100% file format compatible** - shares the same `.claude/mind.mv2` file
- **Works with both tools** - users can switch between Claude Code and OpenCode seamlessly
- **Available on npm** - easy installation with `npm install opencode-brain`
- **Same memvid SDK** - uses the same underlying technology
- **Zero lock-in** - users aren't forced to choose between Claude Code and OpenCode

## Links
- **npm:** https://www.npmjs.com/package/opencode-brain
- **GitHub:** https://github.com/deiviuds/opencode-brain
- **Documentation:** See README for full details

## Changes in this PR
Added an "OpenCode Support" section to the README after the CLI section, linking to opencode-brain for OpenCode users who want the same memory persistence functionality.

This helps expand the reach of claude-brain's memory format to the OpenCode community while maintaining full compatibility.